### PR TITLE
fix: version switcher

### DIFF
--- a/docs/make_vers_switcher.py
+++ b/docs/make_vers_switcher.py
@@ -24,7 +24,7 @@ for idx, vers in enumerate(all_vers):
         name = f"dev ({vers})"
     else:
         name = vers
-    vers_switcher.append({"name": name, "version": vers.lstrip('v')})
+    vers_switcher.append({"name": name, "version": vers.lstrip('v'), "url": "/docs/"+vers+"/"})
 
 with docs_dir.joinpath('switcher.json').open('w') as fh:
     json.dump(vers_switcher, fh, indent=4)

--- a/docs/make_vers_switcher.py
+++ b/docs/make_vers_switcher.py
@@ -2,10 +2,18 @@ import json
 from pathlib import Path
 import re
 
+def pad_version(version,pad_length=3):
+    p=""
+    for n in re.findall(r'\d+', version):
+        p=p+str(n.zfill(pad_length))
+    if 'a' not in version:
+        p=p+'999'   # stable versions before pre-releases (with `reverse=True`)
+    return p
+
 docs_dir = Path(__file__).parent.resolve()
 all_vers = sorted(
     (i.name for i in docs_dir.glob('*') if i.is_dir() and not i.is_symlink()),
-    key=lambda i: i + 'z', # stable versions before pre-releases (with `reverse=True`)
+    key=lambda i: pad_version(i),
     reverse=True,
 )
 
@@ -28,3 +36,4 @@ for idx, vers in enumerate(all_vers):
 
 with docs_dir.joinpath('switcher.json').open('w') as fh:
     json.dump(vers_switcher, fh, indent=4)
+

--- a/docs/switcher.json
+++ b/docs/switcher.json
@@ -1,46 +1,6 @@
 [
     {
-        "name": "dev (v0.2.0a9)",
-        "version": "0.2.0a9",
-        "url": "/docs/v0.2.0a9/"
-    },
-    {
-        "name": "v0.2.0a8",
-        "version": "0.2.0a8",
-        "url": "/docs/v0.2.0a8/"
-    },
-    {
-        "name": "v0.2.0a7",
-        "version": "0.2.0a7",
-        "url": "/docs/v0.2.0a7/"
-    },
-    {
-        "name": "v0.2.0a6",
-        "version": "0.2.0a6",
-        "url": "/docs/v0.2.0a6/"
-    },
-    {
-        "name": "v0.2.0a5",
-        "version": "0.2.0a5",
-        "url": "/docs/v0.2.0a5/"
-    },
-    {
-        "name": "v0.2.0a4",
-        "version": "0.2.0a4",
-        "url": "/docs/v0.2.0a4/"
-    },
-    {
-        "name": "v0.2.0a3",
-        "version": "0.2.0a3",
-        "url": "/docs/v0.2.0a3/"
-    },
-    {
-        "name": "v0.2.0a2",
-        "version": "0.2.0a2",
-        "url": "/docs/v0.2.0a2/"
-    },
-    {
-        "name": "v0.2.0a23",
+        "name": "dev (v0.2.0a23)",
         "version": "0.2.0a23",
         "url": "/docs/v0.2.0a23/"
     },
@@ -58,11 +18,6 @@
         "name": "v0.2.0a20",
         "version": "0.2.0a20",
         "url": "/docs/v0.2.0a20/"
-    },
-    {
-        "name": "v0.2.0a1",
-        "version": "0.2.0a1",
-        "url": "/docs/v0.2.0a1/"
     },
     {
         "name": "v0.2.0a19",
@@ -103,6 +58,51 @@
         "name": "v0.2.0a10",
         "version": "0.2.0a10",
         "url": "/docs/v0.2.0a10/"
+    },
+    {
+        "name": "v0.2.0a9",
+        "version": "0.2.0a9",
+        "url": "/docs/v0.2.0a9/"
+    },
+    {
+        "name": "v0.2.0a8",
+        "version": "0.2.0a8",
+        "url": "/docs/v0.2.0a8/"
+    },
+    {
+        "name": "v0.2.0a7",
+        "version": "0.2.0a7",
+        "url": "/docs/v0.2.0a7/"
+    },
+    {
+        "name": "v0.2.0a6",
+        "version": "0.2.0a6",
+        "url": "/docs/v0.2.0a6/"
+    },
+    {
+        "name": "v0.2.0a5",
+        "version": "0.2.0a5",
+        "url": "/docs/v0.2.0a5/"
+    },
+    {
+        "name": "v0.2.0a4",
+        "version": "0.2.0a4",
+        "url": "/docs/v0.2.0a4/"
+    },
+    {
+        "name": "v0.2.0a3",
+        "version": "0.2.0a3",
+        "url": "/docs/v0.2.0a3/"
+    },
+    {
+        "name": "v0.2.0a2",
+        "version": "0.2.0a2",
+        "url": "/docs/v0.2.0a2/"
+    },
+    {
+        "name": "v0.2.0a1",
+        "version": "0.2.0a1",
+        "url": "/docs/v0.2.0a1/"
     },
     {
         "name": "v0.2.0a0",

--- a/docs/switcher.json
+++ b/docs/switcher.json
@@ -1,90 +1,112 @@
 [
     {
         "name": "dev (v0.2.0a9)",
-        "version": "0.2.0a9"
+        "version": "0.2.0a9",
+        "url": "/docs/v0.2.0a9/"
     },
     {
         "name": "v0.2.0a8",
-        "version": "0.2.0a8"
+        "version": "0.2.0a8",
+        "url": "/docs/v0.2.0a8/"
     },
     {
         "name": "v0.2.0a7",
-        "version": "0.2.0a7"
+        "version": "0.2.0a7",
+        "url": "/docs/v0.2.0a7/"
     },
     {
         "name": "v0.2.0a6",
-        "version": "0.2.0a6"
+        "version": "0.2.0a6",
+        "url": "/docs/v0.2.0a6/"
     },
     {
         "name": "v0.2.0a5",
-        "version": "0.2.0a5"
+        "version": "0.2.0a5",
+        "url": "/docs/v0.2.0a5/"
     },
     {
         "name": "v0.2.0a4",
-        "version": "0.2.0a4"
+        "version": "0.2.0a4",
+        "url": "/docs/v0.2.0a4/"
     },
     {
         "name": "v0.2.0a3",
-        "version": "0.2.0a3"
+        "version": "0.2.0a3",
+        "url": "/docs/v0.2.0a3/"
     },
     {
         "name": "v0.2.0a2",
-        "version": "0.2.0a2"
+        "version": "0.2.0a2",
+        "url": "/docs/v0.2.0a2/"
     },
     {
         "name": "v0.2.0a23",
-        "version": "0.2.0a23"
+        "version": "0.2.0a23",
+        "url": "/docs/v0.2.0a23/"
     },
     {
         "name": "v0.2.0a22",
-        "version": "0.2.0a22"
+        "version": "0.2.0a22",
+        "url": "/docs/v0.2.0a22/"
     },
     {
         "name": "v0.2.0a21",
-        "version": "0.2.0a21"
+        "version": "0.2.0a21",
+        "url": "/docs/v0.2.0a21/"
     },
     {
         "name": "v0.2.0a20",
-        "version": "0.2.0a20"
+        "version": "0.2.0a20",
+        "url": "/docs/v0.2.0a20/"
     },
     {
         "name": "v0.2.0a1",
-        "version": "0.2.0a1"
+        "version": "0.2.0a1",
+        "url": "/docs/v0.2.0a1/"
     },
     {
         "name": "v0.2.0a19",
-        "version": "0.2.0a19"
+        "version": "0.2.0a19",
+        "url": "/docs/v0.2.0a19/"
     },
     {
         "name": "v0.2.0a18",
-        "version": "0.2.0a18"
+        "version": "0.2.0a18",
+        "url": "/docs/v0.2.0a18/"
     },
     {
         "name": "v0.2.0a15",
-        "version": "0.2.0a15"
+        "version": "0.2.0a15",
+        "url": "/docs/v0.2.0a15/"
     },
     {
         "name": "v0.2.0a14",
-        "version": "0.2.0a14"
+        "version": "0.2.0a14",
+        "url": "/docs/v0.2.0a14/"
     },
     {
         "name": "v0.2.0a13",
-        "version": "0.2.0a13"
+        "version": "0.2.0a13",
+        "url": "/docs/v0.2.0a13/"
     },
     {
         "name": "v0.2.0a12",
-        "version": "0.2.0a12"
+        "version": "0.2.0a12",
+        "url": "/docs/v0.2.0a12/"
     },
     {
         "name": "v0.2.0a11",
-        "version": "0.2.0a11"
+        "version": "0.2.0a11",
+        "url": "/docs/v0.2.0a11/"
     },
     {
         "name": "v0.2.0a10",
-        "version": "0.2.0a10"
+        "version": "0.2.0a10",
+        "url": "/docs/v0.2.0a10/"
     },
     {
         "name": "v0.2.0a0",
-        "version": "0.2.0a0"
+        "version": "0.2.0a0",
+        "url": "/docs/v0.2.0a0/"
     }
 ]


### PR DESCRIPTION
Fixes version switcher dropdown menu hrefs by using Root-relative urls, which are specified in the switcher.json file.
Also fixes version sorting in the same menu.

Resolves #1 
Resolves #4 